### PR TITLE
NCIATWP-10380: GA4 analytics (Author Arranger)

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,8 +1,19 @@
 import { Component } from '@angular/core';
+import { Router, NavigationEnd } from '@angular/router';
 
 @Component({
   selector: 'author-arranger-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent {}
+export class AppComponent {
+  constructor(private router: Router) {
+    this.router.events.subscribe(event => {
+      if (event instanceof NavigationEnd && (window as any).gtag) {
+        (window as any).gtag('event', 'page_view', {
+          page_path: event.urlAfterRedirects
+        });
+      }
+    });
+  }
+}

--- a/src/app/components/preview/preview.component.ts
+++ b/src/app/components/preview/preview.component.ts
@@ -51,6 +51,9 @@ export class PreviewComponent implements OnChanges {
         this.state.file.filename,
         this.state.markup
       );
+      if ((window as any).gtag) {
+        (window as any).gtag('event', 'download_document', {});
+      }
 /*
       this.arranger.downloadPreview(
         this.state.file.filename,

--- a/src/app/components/web-tool/web-tool.component.ts
+++ b/src/app/components/web-tool/web-tool.component.ts
@@ -31,6 +31,12 @@ export class WebToolComponent implements OnInit {
     try {
       const newState = await this.arranger.arrange(this.state);
       this.merge(newState);
+      if ((window as any).gtag) {
+        (window as any).gtag('event', 'arrange', {
+          author_count: (this.state.authors || []).length,
+          affiliation_count: (this.state.affiliations || []).length
+        });
+      }
     } catch(e) {
       console.log(e);
     } finally {

--- a/src/index.html
+++ b/src/index.html
@@ -18,8 +18,19 @@
   <!-- Adobe DAP Snippet -->
   <script defer src="//assets.adobedtm.com/f1bfa9f7170c81b1a9a9ecdcc6c5215ee0b03c84/satelliteLib-4b219b82c4737db0e1797b6c511cf10c802c95cb.js"></script>
 
-  <!-- Google Analytics Snippet -->
-  <script async defer src="https://www.googletagmanager.com/gtag/js?id=UA-62346354-11"></script>
+  <!-- Google Analytics 4 (GA4) -->
+  <script>
+    (function () {
+      var GA_ID = "G-J2CDLKKDFL";
+      if (!/^G-[A-Z0-9]+$/.test(GA_ID)) return;
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){ dataLayer.push(arguments); }
+      window.gtag = gtag; window.GA_MEASUREMENT_ID = GA_ID;
+      gtag('js', new Date());
+      gtag('config', GA_ID, { send_page_view: false });
+      var s=document.createElement('script'); s.async=true; s.src='https://www.googletagmanager.com/gtag/js?id='+GA_ID; document.head.appendChild(s);
+    })();
+  </script>
 
   <!-- Web Components  -->
   <script src="https://cbiit.github.io/nci-softwaresolutions-elements/components/include-html.js"></script>
@@ -247,14 +258,6 @@
     );
   </script>
 -->
-
-  <!-- End Google Analytics Snippet -->
-  <script defer>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-62346354-11');
-  </script>
 
   <!-- End Adobe DAP Snippet -->
   <script defer>(function _pb(){window._satellite !== undefined ? _satellite.pageBottom() : _pb, 1000})()</script>


### PR DESCRIPTION
## Ticket
NCIATWP-10380 — https://tracker.nci.nih.gov/browse/NCIATWP-10380

## Summary of changes
- Removed the dead Universal Analytics (`UA-62346354-11`) gtag snippets from `src/index.html`.
- Added a GA4 bootstrap in `src/index.html` with the hardcoded Measurement ID `G-J2CDLKKDFL`. `send_page_view` is disabled so the SPA owns page-view tracking.
- SPA route tracking the Angular way: `AppComponent` (`src/app/app.component.ts`) injects `Router` and sends a guarded `gtag('event','page_view', { page_path })` on every `NavigationEnd`, using `urlAfterRedirects` (app routes only).
- Added guarded, PII-free custom events:
  - `web-tool.component.ts` `arrange()` → `gtag('event','arrange', { author_count, affiliation_count })` (counts only).
  - `preview.component.ts` `downloadPreview()` → `gtag('event','download_document', {})`.

## Where the reviewer can test
- Deploy `dev_10380` to dev (Actions → Deploy Frontend → `tier=dev`), then open the dev site.
- In DevTools → Network, filter for `collect`.
- Navigate between routes (`#`, `#web-tool`, `#user-guide`) — each `NavigationEnd` fires a `page_view` `collect` request.
- Upload a sheet and click Arrange → `arrange` event; download the document → `download_document` event.
- Confirm requests carry `tid=G-J2CDLKKDFL`.

## Other info
- Route tracking uses Angular `Router.events` / `NavigationEnd` (this is an Angular app — not react-router).
- All `gtag` calls are guarded (`if (window.gtag)`).
- The legacy UA tag was removed.
- No PII is sent: `page_path` is an app route; `arrange` carries only integer counts; no uploaded author/affiliation data is included.
- `docs/` is the committed build output; this PR contains source changes only (no rebuilt `docs/`). The deploy workflow rebuilds.

