### PR TITLE
NCIATWP-10398: Fix change detection for worker-driven state updates

### DIFF
--- a/src/app/components/file-input/file-input.component.ts
+++ b/src/app/components/file-input/file-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, EventEmitter, Output } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit, EventEmitter, Output } from '@angular/core';
 import { FormControl, FormGroup, FormBuilder } from '@angular/forms';
 import { FileService } from '../../services/file/file.service';
 import { FileInfo, DEFAULT_HEADERS } from '../../app.models';
@@ -20,7 +20,7 @@ export class FileInputComponent implements OnInit {
 
   loading: boolean = false;
 
-  constructor(private fileService: FileService) { }
+  constructor(private fileService: FileService, private cdr: ChangeDetectorRef) { }
 
   ngOnInit() {}
 
@@ -114,6 +114,8 @@ export class FileInputComponent implements OnInit {
       }
     } finally {
       this.loading = false;
+      // async file parsing completes outside change-detection triggers
+      this.cdr.markForCheck();
     }
   }
 
@@ -157,6 +159,8 @@ export class FileInputComponent implements OnInit {
         this.alerts.push(e);
     } finally {
       this.loading = false;
+      // async file parsing completes outside change-detection triggers
+      this.cdr.markForCheck();
     }
   }
 

--- a/src/app/components/web-tool/web-tool.component.ts
+++ b/src/app/components/web-tool/web-tool.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { ArrangerService } from '../../services/arranger/arranger.service';
 import { AppState, INITIAL_APP_STATE, DeepPartial, Author } from '../../app.models';
 import { cloneDeep } from 'lodash';
@@ -16,12 +16,15 @@ export class WebToolComponent implements OnInit {
 
   loading: boolean = false;
 
-  constructor(private arranger: ArrangerService) { }
+  constructor(private arranger: ArrangerService, private cdr: ChangeDetectorRef) { }
 
   ngOnInit() { }
 
   merge(newState: DeepPartial<AppState>) {
     this.state = Object.assign({}, this.state, newState);
+    // state updates often arrive from web-worker responses, outside any
+    // change-detection trigger — mark the view dirty so they render
+    this.cdr.markForCheck();
     if (!environment.production)
       this.log(this.state);
   }

--- a/src/app/services/worker/worker.service.ts
+++ b/src/app/services/worker/worker.service.ts
@@ -1,9 +1,11 @@
-import { Injectable } from '@angular/core';
+import { ApplicationRef, Injectable, NgZone } from '@angular/core';
 import { environment } from '../../../environments/environment';
 @Injectable({
   providedIn: 'root'
 })
 export class WorkerService {
+
+  constructor(private zone: NgZone, private appRef: ApplicationRef) { }
 
   getWorker(fn: Function): Worker {
     if (!environment.production)
@@ -15,21 +17,28 @@ export class WorkerService {
     return new Promise((resolve, reject) => {
       const messageId = Math.random();
 
-      worker.addEventListener(
-        'message',
-        function messageListener({data}: MessageEvent) {
-          if (data.messageId !== undefined && data.messageId !== messageId) return;
-          worker.removeEventListener('message', messageListener);
+      const messageListener = ({data}: MessageEvent) => {
+        if (data.messageId !== undefined && data.messageId !== messageId) return;
+        worker.removeEventListener('message', messageListener);
+        // resolve within the Angular zone, then run change detection so
+        // state changes driven by worker responses are rendered; a
+        // macrotask is used so all await continuations settle first
+        this.zone.run(() => {
           if (data.result !== undefined)
             resolve(data.result as E);
           else
             resolve(null);
-        },
-      );
+        });
+        setTimeout(() => this.appRef.tick());
+      };
+      worker.addEventListener('message', messageListener);
 
       worker.addEventListener(
         'error',
-        (event: ErrorEvent) => reject(event),
+        (event: ErrorEvent) => {
+          this.zone.run(() => reject(event));
+          setTimeout(() => this.appRef.tick());
+        },
         {once: true},
       );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { enableProdMode } from '@angular/core';
+import { enableProdMode, provideZoneChangeDetection } from '@angular/core';
 import { platformBrowser } from '@angular/platform-browser';
 
 import { AppModule } from './app/app.module';
@@ -8,5 +8,10 @@ if (environment.production) {
   enableProdMode();
 }
 
-platformBrowser().bootstrapModule(AppModule)
+platformBrowser().bootstrapModule(AppModule, {
+  // Angular 22 defaults NgModule apps to zoneless change detection;
+  // this app's state updates are driven by web-worker responses and
+  // relies on zone.js-based change detection.
+  applicationProviders: [provideZoneChangeDetection()],
+})
   .catch(err => console.error(err));


### PR DESCRIPTION
## Ticket

[NCIATWP-10398](https://tracker.nci.nih.gov/browse/NCIATWP-10398?filter=-1) — Author arranger: Dependabot issue resolution (follow-up to #37)

## Summary

Fixes a rendering defect in the Angular 22 migration found during in-browser regression testing: Angular 22 defaults to zoneless change detection, and this app's state updates arrive via web-worker responses, which mark nothing dirty — so the preview rendered stale state (one interaction behind) or appeared empty after loading a file, until the next unrelated click.

- `WebToolComponent.merge()` now calls `markForCheck()` after every state merge
- `FileInputComponent` marks its view after async file parsing settles
- `WorkerService` resolves worker responses inside `NgZone` and schedules a change-detection pass after await-continuations settle
- Bootstrap passes `provideZoneChangeDetection()` via `applicationProviders`

## Where to test

Verified end-to-end in-browser against the production bundle: sample load renders the preview immediately; chip drag reorder, keyboard reorder, drag-to-Removed transfer and restore, Email tab, and format-field drag reorder all update the preview automatically. Re-verify on the dev tier after deploy.

## Other info

Root-caused by instrumenting the running app (state-write tracing + tick spying): all state writes were correct; `ApplicationRef.tick()` ran but skipped non-dirty views.